### PR TITLE
feature: align istio

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@
 
 ## Go Packages 支持列表
 
-| 分类    | Package                      | 数据类型  & 稳定性状态                                                                                       |
-|---------|------------------------------|-----------------------------------------------------------------------------------------------------|
-| HTTP    | github.com/gin-gonic/gin     | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/gin)      |
-| HTTP    | github.com/go-resty/resty/v2 | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/resty)    |
-| RPC     | google.golang.org/grpc       | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/grpc)     |
-| Redis   | github.com/go-redis/redis/v9 | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/go-redis) |
-| Kafka   | github.com/Shopify/sarama    | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/sarama)   |
-| MongoDB | go.mongodb.org/mongo-driver  | todo: metrics                                                                                       |
-| etcd    | go.etcd.io/etcd/client/v3    | todo: metrics                                                                                       |
+| 分类    | Package                      | 数据类型  & 稳定性状态                                                                                           |
+|---------|------------------------------|---------------------------------------------------------------------------------------------------------|
+| HTTP    | github.com/gin-gonic/gin     | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/gin)          |
+| HTTP    | github.com/go-resty/resty/v2 | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/resty)        |
+| RPC     | google.golang.org/grpc       | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/grpc)         |
+| Redis   | github.com/go-redis/redis/v9 | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/go-redis)     |
+| Kafka   | github.com/Shopify/sarama    | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/sarama)       |
+| MongoDB | go.mongodb.org/mongo-driver  | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/mongo-driver) |
+| etcd    | go.etcd.io/etcd/client/v3    | dev:  [metrics](https://github.com/quwan-sre/observability-go-contrib/tree/master/metrics/etcd)         |

--- a/metrics/common/cache_metrics.go
+++ b/metrics/common/cache_metrics.go
@@ -7,17 +7,17 @@ import (
 )
 
 const (
-	DefaultCacheRequestMetricName = "apm_cache_send_request_duration_seconds"
+	DefaultCacheRequestMetricName = "apm_cache_send_request_duration_milliseconds"
 )
 
 var (
 	DefaultCacheRequestMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            DefaultCacheRequestMetricName,
-		Buckets:                         []float64{0.00025, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.25, 0.5, 1, 2.5, 5, 10},
+		Buckets:                         []float64{0.25, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 3000, 5000},
 		NativeHistogramBucketFactor:     1.4,
-		NativeHistogramZeroThreshold:    0.0001,
+		NativeHistogramZeroThreshold:    0.1,
 		NativeHistogramMinResetDuration: 5 * time.Minute,
-		NativeHistogramMaxZeroThreshold: 0.01,
+		NativeHistogramMaxZeroThreshold: 10,
 		NativeHistogramMaxBucketNumber:  20,
 	}, []string{"sdk", "cache_type", "cache_addr", "command", "response_status"})
 )

--- a/metrics/common/cache_metrics.go
+++ b/metrics/common/cache_metrics.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	DefaultCacheRequestMetricName = "apm_cache_request_duration_seconds"
+	DefaultCacheRequestMetricName = "apm_cache_send_request_duration_seconds"
 )
 
 var (

--- a/metrics/common/database_metrics.go
+++ b/metrics/common/database_metrics.go
@@ -7,17 +7,17 @@ import (
 )
 
 const (
-	DefaultDatabaseSendRequestMetricName = "apm_database_send_request_duration_seconds"
+	DefaultDatabaseSendRequestMetricName = "apm_database_send_request_duration_milliseconds"
 )
 
 var (
 	DefaultDatabaseSendRequestMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            DefaultDatabaseSendRequestMetricName,
-		Buckets:                         []float64{0.001, 0.0025, 0.005, 0.01, 0.02, 0.05, 0.1, 0.5, 1, 2.5, 5, 7.5, 10},
+		Buckets:                         []float64{1, 2.5, 5, 10, 20, 50, 100, 500, 1000, 2500, 5000, 7500, 10000},
 		NativeHistogramBucketFactor:     1.4,
-		NativeHistogramZeroThreshold:    0.001,
+		NativeHistogramZeroThreshold:    1,
 		NativeHistogramMinResetDuration: 5 * time.Minute,
-		NativeHistogramMaxZeroThreshold: 0.05,
+		NativeHistogramMaxZeroThreshold: 50,
 		NativeHistogramMaxBucketNumber:  20,
 	}, []string{"sdk", "database_type", "database_addr", "response_status", "query_type"})
 )

--- a/metrics/common/init.go
+++ b/metrics/common/init.go
@@ -26,8 +26,8 @@ func init() {
 
 	go func() {
 		for {
-			// reset all metrics every 23-24 hours
-			time.Sleep(time.Duration((60*23)+rand.Intn(60)) * time.Minute)
+			// reset all metrics every 6-7 hours
+			time.Sleep(time.Duration((60*6)+rand.Intn(60)) * time.Minute)
 
 			// rpc metrics
 			DefaultRPCReceiveRequestMetric.Reset()

--- a/metrics/common/init.go
+++ b/metrics/common/init.go
@@ -26,8 +26,8 @@ func init() {
 
 	go func() {
 		for {
-			// reset all metrics every 25-35 minutes
-			time.Sleep(time.Duration(25+rand.Intn(10)) * time.Minute)
+			// reset all metrics every 23-24 hours
+			time.Sleep(time.Duration((60*23)+rand.Intn(60)) * time.Minute)
 
 			// rpc metrics
 			DefaultRPCReceiveRequestMetric.Reset()

--- a/metrics/common/rpc_enum.go
+++ b/metrics/common/rpc_enum.go
@@ -10,3 +10,7 @@ const (
 	RPCProtocolHTTP = "http"
 	RPCProtocolGRPC = "grpc"
 )
+
+const (
+	RPCUnknownString = "unknown"
+)

--- a/metrics/common/rpc_metrics.go
+++ b/metrics/common/rpc_metrics.go
@@ -7,28 +7,28 @@ import (
 )
 
 const (
-	DefaultRPCReceiveRequestMetricName = "apm_rpc_receive_request_duration_seconds"
-	DefaultRPCSendRequestMetricName    = "apm_rpc_send_request_duration_seconds"
+	DefaultRPCReceiveRequestMetricName = "apm_rpc_receive_request_duration_milliseconds"
+	DefaultRPCSendRequestMetricName    = "apm_rpc_send_request_duration_milliseconds"
 )
 
 var (
 	DefaultRPCReceiveRequestMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            DefaultRPCReceiveRequestMetricName,
-		Buckets:                         []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
+		Buckets:                         []float64{0.5, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 300000, 600000, 1800000, 3600000},
 		NativeHistogramBucketFactor:     1.4,
-		NativeHistogramZeroThreshold:    0.001,
+		NativeHistogramZeroThreshold:    0.5,
 		NativeHistogramMinResetDuration: 5 * time.Minute,
-		NativeHistogramMaxZeroThreshold: 0.05,
+		NativeHistogramMaxZeroThreshold: 50,
 		NativeHistogramMaxBucketNumber:  20,
-	}, []string{"sdk", "request_protocol", "endpoint", "rpc_status_code", "http_status_code"})
+	}, []string{"sdk", "request_protocol", "request_target", "request_path", "grpc_response_status", "response_code"})
 
 	DefaultRPCSendRequestMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            DefaultRPCSendRequestMetricName,
-		Buckets:                         []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
+		Buckets:                         []float64{0.5, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 300000, 600000, 1800000, 3600000},
 		NativeHistogramBucketFactor:     1.4,
-		NativeHistogramZeroThreshold:    0.001,
+		NativeHistogramZeroThreshold:    0.5,
 		NativeHistogramMinResetDuration: 5 * time.Minute,
-		NativeHistogramMaxZeroThreshold: 0.05,
+		NativeHistogramMaxZeroThreshold: 50,
 		NativeHistogramMaxBucketNumber:  20,
-	}, []string{"sdk", "request_protocol", "endpoint", "rpc_status_code", "http_status_code"})
+	}, []string{"sdk", "request_protocol", "request_target", "request_path", "grpc_response_status", "response_code"})
 )

--- a/metrics/go-redis/go_redis.go
+++ b/metrics/go-redis/go_redis.go
@@ -76,7 +76,7 @@ func (h metricsHook) AfterProcess(ctx context.Context, cmd rdsV9.Cmder) error {
 		labels[k] = v
 	}
 
-	common.DefaultCacheRequestMetric.With(labels).Observe(latency.Seconds())
+	common.DefaultCacheRequestMetric.With(labels).Observe(latency.Seconds() * 1000)
 	return nil
 }
 
@@ -117,6 +117,6 @@ func (h metricsHook) AfterProcessPipeline(ctx context.Context, cmds []rdsV9.Cmde
 		labels[k] = v
 	}
 
-	common.DefaultCacheRequestMetric.With(labels).Observe(latency.Seconds())
+	common.DefaultCacheRequestMetric.With(labels).Observe(latency.Seconds() * 1000)
 	return nil
 }

--- a/metrics/mongo-driver/mongo_driver.go
+++ b/metrics/mongo-driver/mongo_driver.go
@@ -30,7 +30,7 @@ func Succeeded(ctx context.Context, evt *event.CommandSucceededEvent) {
 		"database_addr":   parseConnectionID(evt.ConnectionID),
 		"response_status": common.DatabaseResponseStatusSuccess,
 		"query_type":      evt.CommandName,
-	}).Observe(float64(evt.DurationNanos) / float64(time.Second))
+	}).Observe(float64(evt.DurationNanos) / float64(time.Millisecond))
 }
 
 func Failed(ctx context.Context, evt *event.CommandFailedEvent) {
@@ -40,7 +40,7 @@ func Failed(ctx context.Context, evt *event.CommandFailedEvent) {
 		"database_addr":   parseConnectionID(evt.ConnectionID),
 		"response_status": common.DatabaseResponseStatusError,
 		"query_type":      evt.CommandName,
-	}).Observe(float64(evt.DurationNanos) / float64(time.Second))
+	}).Observe(float64(evt.DurationNanos) / float64(time.Millisecond))
 }
 
 func parseConnectionID(connectionID string) string {

--- a/metrics/resty/resty.go
+++ b/metrics/resty/resty.go
@@ -48,18 +48,21 @@ func NewAfterResponse() func(c *resty.Client, r *resty.Response) error {
 		}
 
 		latency := time.Now().Sub(t)
-		endpoint := ""
+		endpoint := common.RPCUnknownString
+		host := common.RPCUnknownString
 		if req.RawRequest != nil && req.RawRequest.URL != nil {
 			endpoint = req.RawRequest.URL.Host + req.RawRequest.URL.Path
+			host = req.RawRequest.URL.Host
 		}
 
 		common.DefaultRPCSendRequestMetric.With(prometheus.Labels{
-			"sdk":              common.RPCSDKResty,
-			"request_protocol": common.RPCProtocolHTTP,
-			"endpoint":         endpoint,
-			"rpc_status_code":  strconv.Itoa(int(grpc.OK)),
-			"http_status_code": strconv.Itoa(r.StatusCode()),
-		}).Observe(latency.Seconds())
+			"sdk":                  common.RPCSDKResty,
+			"request_protocol":     common.RPCProtocolHTTP,
+			"request_target":       host,
+			"request_path":         endpoint,
+			"grpc_response_status": strconv.Itoa(int(grpc.OK)),
+			"response_code":        strconv.Itoa(r.StatusCode()),
+		}).Observe(latency.Seconds() * 1000)
 		return nil
 	}
 }


### PR DESCRIPTION
## Changed
- All histogram metrics renamed to xxx_milliseconds, and observed value is now in `ms` format.
- All RPC metrics now contains labels: `[]string{"sdk", "request_protocol", "request_target", "request_path", "grpc_response_status", "response_code"}`
- All RPC metrics have the same buckets def as istio standard metrics, which is: `[]float64{0.5, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 300000, 600000, 1800000, 3600000}`