### PR TITLE
feature: ttl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
+github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/metrics/common/init.go
+++ b/metrics/common/init.go
@@ -1,9 +1,6 @@
 package common
 
 import (
-	"math/rand"
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -24,24 +21,9 @@ func init() {
 		DefaultDatabaseSendRequestMetric,
 	)
 
-	go func() {
-		for {
-			// reset all metrics every 6-7 hours
-			time.Sleep(time.Duration((60*6)+rand.Intn(60)) * time.Minute)
-
-			// rpc metrics
-			DefaultRPCReceiveRequestMetric.Reset()
-			DefaultRPCSendRequestMetric.Reset()
-
-			// cache metrics
-			DefaultCacheRequestMetric.Reset()
-
-			// mq metrics
-			DefaultMQReceiveMsgMetric.Reset()
-			DefaultMQSendMsgMetric.Reset()
-
-			// database metrics
-			DefaultDatabaseSendRequestMetric.Reset()
-		}
-	}()
+	// init LRU cache for metrics
+	{
+		NewRPCSendRequestCache()
+		NewRPCReceiveRequestCache()
+	}
 }

--- a/metrics/common/rpc_metrics.go
+++ b/metrics/common/rpc_metrics.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/bluele/gcache"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,6 +10,15 @@ import (
 const (
 	DefaultRPCReceiveRequestMetricName = "apm_rpc_receive_request_duration_milliseconds"
 	DefaultRPCSendRequestMetricName    = "apm_rpc_send_request_duration_milliseconds"
+)
+
+const (
+	// MaxRequestPathCount represent how many request_path could be stored in metrics vec.
+	// It's set to avoid high cardinality.
+	MaxRequestPathCount = 1000
+	// MaxIdleTime represent the TTL for a idle request_path. When a request_path is not
+	// touched for MaxIdleTime, it (related Vec) will be deleted.
+	MaxIdleTime = 6 * time.Hour
 )
 
 var (
@@ -32,3 +42,62 @@ var (
 		NativeHistogramMaxBucketNumber:  20,
 	}, []string{"sdk", "request_protocol", "request_target", "request_path", "grpc_response_status", "response_code"})
 )
+
+var (
+	LRUCacheRPCReceiveRequestMetric gcache.Cache
+	LRUCacheRPCSendRequestMetric    gcache.Cache
+)
+
+func NewRPCSendRequestCache() {
+	cb := gcache.New(MaxRequestPathCount).LRU()
+
+	cb = cb.EvictedFunc(func(k, v interface{}) {
+		if requestPath, ok := k.(string); ok {
+			DefaultRPCSendRequestMetric.DeletePartialMatch(prometheus.Labels{
+				"request_path": requestPath,
+			})
+		}
+	})
+
+	LRUCacheRPCSendRequestMetric = cb.Build()
+
+	go func() {
+		for {
+			time.Sleep(MaxIdleTime)
+			allRequestPath := LRUCacheRPCSendRequestMetric.GetALL(false)
+			validRequestPath := LRUCacheRPCSendRequestMetric.GetALL(true)
+			for k, _ := range allRequestPath {
+				if _, ok := validRequestPath[k]; !ok {
+					LRUCacheRPCSendRequestMetric.Remove(k)
+				}
+			}
+		}
+	}()
+}
+
+func NewRPCReceiveRequestCache() {
+	cb := gcache.New(MaxRequestPathCount).LRU()
+
+	cb = cb.EvictedFunc(func(k, v interface{}) {
+		if requestPath, ok := k.(string); ok {
+			DefaultRPCReceiveRequestMetric.DeletePartialMatch(prometheus.Labels{
+				"request_path": requestPath,
+			})
+		}
+	})
+
+	LRUCacheRPCReceiveRequestMetric = cb.Build()
+
+	go func() {
+		for {
+			time.Sleep(MaxIdleTime)
+			allRequestPath := LRUCacheRPCReceiveRequestMetric.GetALL(false)
+			validRequestPath := LRUCacheRPCReceiveRequestMetric.GetALL(true)
+			for k, _ := range allRequestPath {
+				if _, ok := validRequestPath[k]; !ok {
+					LRUCacheRPCReceiveRequestMetric.Remove(k)
+				}
+			}
+		}
+	}()
+}

--- a/metrics/grpc/grpc.go
+++ b/metrics/grpc/grpc.go
@@ -37,6 +37,7 @@ func NewUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 				"grpc_response_status": strconv.Itoa(int(code)),
 				"response_code":        "0",
 			}).Observe(latency.Seconds() * 1000)
+			common.LRUCacheRPCReceiveRequestMetric.SetWithExpire(requestPath, nil, common.MaxIdleTime)
 		}()
 
 		resp, err = handler(ctx, req)
@@ -75,6 +76,7 @@ func NewUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 				"grpc_response_status": strconv.Itoa(int(code)),
 				"response_code":        "0",
 			}).Observe(latency.Seconds() * 1000)
+			common.LRUCacheRPCSendRequestMetric.SetWithExpire(requestPath, nil, common.MaxIdleTime)
 		}()
 
 		err = invoker(ctx, method, req, reply, cc, opts...)
@@ -122,6 +124,7 @@ func (w *wrapClientStream) SendMsg(m interface{}) error {
 			"grpc_response_status": strconv.Itoa(int(code)),
 			"response_code":        "0",
 		}).Observe(latency.Seconds() * 1000)
+		common.LRUCacheRPCSendRequestMetric.SetWithExpire(w.requestPath, nil, common.MaxIdleTime)
 	}()
 
 	err = w.ClientStream.SendMsg(m)
@@ -149,6 +152,7 @@ func (w *wrapClientStream) RecvMsg(m interface{}) error {
 			"grpc_response_status": strconv.Itoa(int(code)),
 			"response_code":        "0",
 		}).Observe(latency.Seconds() * 1000)
+		common.LRUCacheRPCReceiveRequestMetric.SetWithExpire(w.requestPath, nil, common.MaxIdleTime)
 	}()
 
 	err = w.ClientStream.RecvMsg(m)
@@ -183,6 +187,7 @@ func (w *wrapServerStream) SendMsg(m interface{}) error {
 			"grpc_response_status": strconv.Itoa(int(code)),
 			"response_code":        "0",
 		}).Observe(latency.Seconds() * 1000)
+		common.LRUCacheRPCSendRequestMetric.SetWithExpire(w.requestPath, nil, common.MaxIdleTime)
 	}()
 
 	err = w.ServerStream.SendMsg(m)
@@ -210,6 +215,7 @@ func (w *wrapServerStream) RecvMsg(m interface{}) error {
 			"grpc_response_status": strconv.Itoa(int(code)),
 			"response_code":        "0",
 		}).Observe(latency.Seconds() * 1000)
+		common.LRUCacheRPCReceiveRequestMetric.SetWithExpire(w.requestPath, nil, common.MaxIdleTime)
 	}()
 
 	err = w.ServerStream.RecvMsg(m)

--- a/metrics/resty/resty.go
+++ b/metrics/resty/resty.go
@@ -48,10 +48,10 @@ func NewAfterResponse() func(c *resty.Client, r *resty.Response) error {
 		}
 
 		latency := time.Now().Sub(t)
-		endpoint := common.RPCUnknownString
+		requestPath := common.RPCUnknownString
 		host := common.RPCUnknownString
 		if req.RawRequest != nil && req.RawRequest.URL != nil {
-			endpoint = req.RawRequest.URL.Host + req.RawRequest.URL.Path
+			requestPath = req.RawRequest.URL.Host + req.RawRequest.URL.Path
 			host = req.RawRequest.URL.Host
 		}
 
@@ -59,10 +59,11 @@ func NewAfterResponse() func(c *resty.Client, r *resty.Response) error {
 			"sdk":                  common.RPCSDKResty,
 			"request_protocol":     common.RPCProtocolHTTP,
 			"request_target":       host,
-			"request_path":         endpoint,
+			"request_path":         requestPath,
 			"grpc_response_status": strconv.Itoa(int(grpc.OK)),
 			"response_code":        strconv.Itoa(r.StatusCode()),
 		}).Observe(latency.Seconds() * 1000)
+		common.LRUCacheRPCSendRequestMetric.SetWithExpire(requestPath, nil, common.MaxIdleTime)
 		return nil
 	}
 }

--- a/test/e2e/metrics/main_test.go
+++ b/test/e2e/metrics/main_test.go
@@ -46,5 +46,6 @@ func TestMain(t *testing.M) {
 	if err != nil {
 		log.Fatalf("test failed read body, err: %v", err)
 	}
+	resp.Body.Close()
 	fmt.Println(string(bodyBytes))
 }

--- a/test/e2e/metrics/resty_test.go
+++ b/test/e2e/metrics/resty_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -18,8 +19,8 @@ func TestRestyClient(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		for i := 0; i < 10; i++ {
-			restyClient.R().Get(tc)
+		for i := 0; i < 1005; i++ {
+			restyClient.R().Get(tc + fmt.Sprintf("_%d", i))
 		}
 	}
 }


### PR DESCRIPTION
## Added
- now RPC metrics is limited by both idle time and cardinality count of `request_path` label.
  - if one `request_path` is not touched (or actually, `Observe`) in 6 hours, related **Vec** (with same `request_path`) will be delete .
  - if cardinality of `request_path` is going to exceed 1000, Vec will be deleted (in LRU way).